### PR TITLE
watchAll instead of watch

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -28,7 +28,7 @@ const argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
+  argv.push('--watchAll');
 }
 
 // @remove-on-eject-begin


### PR DESCRIPTION
watch only works in environments using git. watchAll works for everyone, albeit at a performance cost.
